### PR TITLE
bugfix: handling Windows line separator

### DIFF
--- a/jd-lib/src/main/java/jd/ide/intellij/JavaDecompiler.java
+++ b/jd-lib/src/main/java/jd/ide/intellij/JavaDecompiler.java
@@ -130,8 +130,8 @@ public class JavaDecompiler {
 		}
 
 		String src = decompile(basePath, className);
-		// TODO is windows OK with \n?
-		if (src == null || src.startsWith("class \n{")) {
+		final String LS = System.getProperty("line.separator");
+		if (src == null || src.startsWith("class " + LS + "{")) {
 			// decompilation failed - wrong package?
 			final File baseFile = new File(basePath);
 			if (baseFile.isDirectory()) {


### PR DESCRIPTION
Ahoj Pepo,
potřeboval jsem dávkově dekompilovat víc souborů a udělalo mi velkou radost, když jsem objevil Tvoji utilitu. Bohužel na Windows to ve stavu z HEADu Tvého masteru nejde, zjistil jsem, že je to natvrdo zadrátovaným \n. 
Posílám pull request opravy, jestli to chceš zamergovat k sobě. Mně to každopádně pomohlo, díky moc!
Tomáš Záluský